### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,5 @@
   "name": "billingbudgets",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559770",
   "api_shortname": "billingbudgets",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/billing-budgets/latest",
   "api_id": "billingbudgets.googleapis.com",
   "distribution_name": "@google-cloud/billing-budgets",
-  "release_level": "ga",
+  "release_level": "stable",
   "default_version": "v1",
   "language": "nodejs",
   "name_pretty": "Billing Budgets",
@@ -10,5 +10,7 @@
   "product_documentation": "https://cloud.google.com/billing/docs/how-to/budget-api-overview ",
   "requires_billing": true,
   "name": "billingbudgets",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559770"
+  "issue_tracker": "https://issuetracker.google.com/savedsearches/559770",
+  "api_shortname": "billingbudgets",
+  "library_type": ""
 }

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be **stable**. The code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **stable** libraries
+are addressed with the highest priority.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Billing Budgets: Node.js Client](https://github.com/googleapis/nodejs-billing-budgets)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/billing-budgets.svg)](https://www.npmjs.org/package/@google-cloud/billing-budgets)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-billing-budgets/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-billing-budgets)
 
@@ -121,12 +121,6 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 